### PR TITLE
feat: bake code-quality + slot-1 hooks into template (#8)

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,0 +1,21 @@
+name: Code Quality
+
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+  security-events: write
+
+concurrency:
+  group: code-quality-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  code-quality:
+    uses: Diixtra/diixtra-forge/.github/workflows/code-quality.yaml@main
+    with:
+      mode: observe

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md
+
+This repo follows the Diixtra org-wide coding guidelines. The `diixtra-coding-guidelines` skill in `~/.claude/skills/` defines the principles (root-cause-first, layered TDD, security-in-depth, complete solutions, continuous evolution) and per-language modules.
+
+## Code-quality automation
+
+This repo participates in the four-slot org code-quality framework:
+
+1. **Pre-commit hooks** — `lefthook.yml` at the repo root. Run `lefthook install` after cloning. Trim language sections this repo doesn't use.
+2. **CI** — `.github/workflows/code-quality.yaml` calls the org-wide reusable workflow at `Diixtra/diixtra-forge/.github/workflows/code-quality.yaml@main`. Defaults to `mode: observe` (advisory). Flip to `mode: enforce` per the SOP at https://github.com/Diixtra/diixtra-forge/blob/main/docs/code-quality/rollout.md once findings are clean.
+3. **Renovate** — already configured org-wide.
+4. **Skill** — `code-review-triage` in `~/.claude/skills/` interprets CI findings into the four-outcome decision (fix / track / suppress / reject).
+
+## Guideline overrides
+
+If this repo needs to override an org-module rule, document it here under a `## Guideline Overrides` section per the diixtra-coding-guidelines skill template. Temporary overrides must link to an issue.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@
 
 <!-- TODO: Basic usage examples -->
 
+### After cloning a project from this template
+
+```sh
+mise install      # Install pinned tool versions
+lefthook install  # Wire up pre-commit hooks
+```
+
+CI is on observe mode by default. To switch to enforce, follow [the rollout SOP](https://github.com/Diixtra/diixtra-forge/blob/main/docs/code-quality/rollout.md) once the baseline is clean.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,69 @@
+# Diixtra org-wide pre-commit hooks (full template).
+# Source: Diixtra/diixtra-forge/templates/lefthook.yml
+# Trim language sections this repo doesn't use, then `lefthook install` after `mise install`.
+# Slot 1: fast (<2s) staged-file checks. Anything slower belongs in CI.
+# Reference: docs/code-quality/slot-allocation.md in diixtra-forge.
+
+pre-commit:
+  parallel: true
+  commands:
+
+    # Cross-cutting: secret scan on staged files only
+    gitleaks:
+      glob: "*"
+      run: |
+        if command -v gitleaks >/dev/null; then
+          gitleaks protect --staged --redact --no-banner
+        else
+          echo "gitleaks not installed. Add via mise: mise use -g gitleaks@latest"
+          exit 1
+        fi
+
+    # TS/JS: lint + format on staged files
+    biome:
+      glob: "*.{ts,tsx,js,jsx,json,jsonc}"
+      run: bunx biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+      skip:
+        - merge
+        - rebase
+
+    # Python: lint + format on staged files
+    ruff:
+      glob: "*.py"
+      run: |
+        uv run ruff check --fix {staged_files} && uv run ruff format {staged_files}
+      skip:
+        - merge
+        - rebase
+
+    # Go: format + vet on staged files (golangci-lint full run is in CI)
+    gofmt:
+      glob: "*.go"
+      run: |
+        gofmt -l -w {staged_files}
+        if [ -n "$(gofmt -l {staged_files})" ]; then exit 1; fi
+      skip:
+        - merge
+        - rebase
+
+    # Rust: format on staged files
+    rustfmt:
+      glob: "*.rs"
+      run: rustfmt --check {staged_files}
+      skip:
+        - merge
+        - rebase
+
+commit-msg:
+  commands:
+    conventional-commits:
+      run: |
+        commit_msg=$(cat {1})
+        # Skip merge/revert
+        echo "$commit_msg" | grep -qE '^(Merge|Revert)' && exit 0
+        # Conventional Commits regex
+        echo "$commit_msg" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+' || {
+          echo "Commit message must follow Conventional Commits format."
+          echo "Example: 'feat(ci): add lefthook config'"
+          exit 1
+        }

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+lefthook = "1.10"
+gitleaks = "8.21"


### PR DESCRIPTION
## Summary

Bake the four-slot org code-quality baseline into diixtra-template so new repos start green.

## What lands

- `.github/workflows/code-quality.yaml` — caller workflow (observe mode) pointing at \`Diixtra/diixtra-forge/.github/workflows/code-quality.yaml@main\`
- `lefthook.yml` — full org template (TS+Python+Go+Rust+commit-msg); downstream repos trim per their stack
- `AGENTS.md` — stub referencing diixtra-coding-guidelines + the four-slot framework
- `mise.toml` — pin \`lefthook = "1.10"\`, \`gitleaks = "8.21"\`
- `README.md` — post-clone install step (\`mise install && lefthook install\`)

The reusable workflow stays in \`diixtra-forge\`; the template only contains the thin caller, so updates to the workflow propagate to every repo on its next CI run.

Closes #8. Refs Diixtra/diixtra-forge#1636 phase E.